### PR TITLE
Update module mbed to mbed-core in module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "mbed-client-libservice": "~2.0.9",
     "mbed-6lowpan": "~0.0.6",
-    "mbed": "~3.0.1"
+    "mbed-core": "~0.1.1"
   },
   "targetDependencies": {}
 }


### PR DESCRIPTION
Updated "mbed" to "mbed-core: 0.1.1" to avoid build problems.
"mbed-core" is the new name for "mbed".
