### PR TITLE
Update AT24MAC_EUI48_OFFSET value

### DIFF
--- a/source/at24mac.cpp
+++ b/source/at24mac.cpp
@@ -24,7 +24,7 @@
 /* Known memory blocks */
 #define AT24MAC_SERIAL_OFFSET	(0x80)
 #define AT24MAC_EUI64_OFFSET	(0x98)
-#define AT24MAC_EUI48_OFFSET	(0x98)
+#define AT24MAC_EUI48_OFFSET	(0x9A)
 
 #define SERIAL_LEN 16
 #define EUI64_LEN 8


### PR DESCRIPTION
Correcting AT24MAC_EUI48_OFFSET value based on datasheet pages 8 and 9: 
http://www.atmel.com/Images/Atmel-8807-SEEPROM-AT24MAC402-602-Datasheet.pdf