### PR TITLE
Add randomness to transmissions

### DIFF
--- a/atmel-rf-driver/driverRFPhy.h
+++ b/atmel-rf-driver/driverRFPhy.h
@@ -51,8 +51,10 @@ extern "C" {
 #define RF_CALIBRATION_INTERVAL 6000000
 /*Wait ACK for 2.5ms*/
 #define RF_ACK_WAIT_DEFAULT_TIMEOUT 50
-/*CCA Timeout*/
-#define RF_CCA_TIMEOUT  15
+/*Base CCA backoff (50us units) - substitutes for Inter-Frame Spacing*/
+#define RF_CCA_BASE_BACKOFF 13 /* 650us */
+/*CCA random backoff (50us units)*/
+#define RF_CCA_RANDOM_BACKOFF 51 /* 2550us */
 
 #define RF_BUFFER_SIZE 128
 

--- a/source/driverRFPhy.c
+++ b/source/driverRFPhy.c
@@ -545,7 +545,7 @@ int8_t rf_start_cca(uint8_t *data_ptr, uint16_t data_length, uint8_t tx_handle, 
         rf_if_write_frame_buffer(data_ptr, (uint8_t)data_length);
         rf_flags_set(RFF_CCA);
         /*Start CCA timeout*/
-        rf_cca_timer_start(RF_CCA_TIMEOUT);
+        rf_cca_timer_start(RF_CCA_BASE_BACKOFF + randLIB_get_random_in_range(0, RF_CCA_RANDOM_BACKOFF));
         /*Store TX handle*/
         mac_tx_handle = tx_handle;
         platform_exit_critical();


### PR DESCRIPTION
Transmissions need randomness - Nanostack assumes we perform normal
CSMA-CA backoff, and provides no random delay on initial transmissions.
This is particularly important for beacons, which Nanostack transmits
immediately in response to beacon requests. Without driver randomness,
beacons will collide.

Numbers designed to match IEEE 802.15.4 first transmission attempt. On
CSMA retries, Nanostack will need to provide some extra randomness on
top.