### PR TITLE
[ONME-2510] Recalibrate software delay

### DIFF
--- a/source/driverAtmelRFInterface.cpp
+++ b/source/driverAtmelRFInterface.cpp
@@ -45,18 +45,43 @@ static int8_t rf_rssi_base_val = -91;
 static uint8_t rf_if_spi_exchange(uint8_t out);
 
 /* Delay functions for RF Chip SPI access */
+#ifdef __CC_ARM
+__asm static void delay_loop(uint32_t count)
+{
+1
+  SUBS a1, a1, #1
+  BCS  %BT1
+  BX   lr
+}
+#else // GCC
+static void delay_loop(uint32_t count)
+{
+  __asm__ volatile (
+    "%=:\n\t"
+    "SUBS %0, %0, #1\n\t"
+    "BCS  %=b\n\t"
+    : "+r" (count)
+    :
+    : "cc"
+  );
+}
+#endif
+
 static void delay_ns(uint32_t ns)
 {
-  uint32_t ticks_per_us = ((SystemCoreClock/1000)/1000);
-  uint32_t ticks = (ticks_per_us * ns + 500) / 1000; // Round up to next tick value before dividing
-  while(ticks--)
-  {
-#if defined(__CC_ARM)
-    __nop();
-#else
-    __asm__ volatile ("nop");
-#endif
-  }
+  uint32_t cycles_per_us = SystemCoreClock / 1000000;
+  // Cortex-M0 takes 4 cycles per loop (SUB=1, BCS=3)
+  // Cortex-M3 and M4 takes 3 cycles per loop (SUB=1, BCS=2)
+  // Cortex-M7 - who knows?
+  // Cortex M3-M7 have "CYCCNT" - would be better than a software loop, but M0 doesn't
+  // Assume 3 cycles per loop for now - will be 33% slow on M0. No biggie,
+  // as original version of code was 300% slow on M4.
+  // [Note that this very calculation, plus call overhead, will take multiple
+  // cycles. Could well be 100ns on its own... So round down here, startup is
+  // worth at least one loop iteration.]
+  uint32_t count = (cycles_per_us * ns) / 3000;
+
+  delay_loop(count);
 }
 
 #define CS_SELECT()  {RF_CS = 0; delay_ns(180);} // t1 = 180ns, SEL falling edge to MISO active


### PR DESCRIPTION
delay_ns() loop was written on the assumption of one clock cycle per
iteration.

The loop GCC was compiling came out to 4 cycles per iteration on normal
builds, and 13 cycles per iteration in debug builds. The latter was slow
enough that we didn't switch to receive quickly enough after transmitting
to receive an ack, leading to ONME-2510 ("Connectivity issues with debug
build")

Convert the loop to assembler so we have a firmer idea of how long it will
take. Calibrate for a 3-cycle loop on M3/M4 - will be a bit slow on M0.
May be too fast on M7. (However, the set-up time itself is large enough
that we'll probably still take longer than the requested time for the
delays of up to 250ns used in the code.)

M4 calibration checked against the K64F's timers on a long delay.