### PR TITLE
Add size specifier BCS instruction to fix error

### DIFF
--- a/source/driverAtmelRFInterface.cpp
+++ b/source/driverAtmelRFInterface.cpp
@@ -59,7 +59,7 @@ static void delay_loop(uint32_t count)
   __asm volatile(
     "loop: \n"
     " SUBS %0, %0, #1 \n"
-    " BCS  loop\n"
+    " BCS.n  loop\n"
     : "+r" (count)
     :
     : "cc"


### PR DESCRIPTION
Add size specifier to the BCS instruction for compatibility with older
versions of the IAR assembler.