### PR TITLE
Add mbed-cli configuration, fallback to NC

### DIFF
--- a/source/at24mac.cpp
+++ b/source/at24mac.cpp
@@ -16,8 +16,6 @@
 #include "at24mac.h"
 #include "mbed-drivers/mbed.h"
 
-#ifdef YOTTA_CFG_ATMEL_RF_I2C_SDA
-
 /* Device addressing */
 #define AT24MAC_EEPROM_ADDRESS		(0x0A<<4)
 #define AT24MAC_RW_PROTECT_ADDRESS	(0x06<<4)
@@ -32,7 +30,7 @@
 #define EUI64_LEN 8
 #define EUI48_LEN 6
 
-I2C i2c(YOTTA_CFG_ATMEL_RF_I2C_SDA, YOTTA_CFG_ATMEL_RF_I2C_SCL);
+I2C i2c(PIN_I2C_SDA, PIN_I2C_SCL);
 
 /**
  * Read unique serial number from chip.
@@ -72,6 +70,3 @@ extern "C" int at24mac_read_eui48(void *buf)
 		return -1; //No ACK
 	return i2c.read(AT24MAC_SERIAL_ADDRESS, (char*)buf, EUI48_LEN);
 }
-
-#endif // YOTTA_CFG_ATMEL_RF_I2C_SDA
-

--- a/source/at24mac.h
+++ b/source/at24mac.h
@@ -52,14 +52,39 @@
  *  }
  */
 
+/* mbed-cli configuration */
+#ifdef MBED_CONF_ATMEL_RF_I2C_SDA
+#define PIN_I2C_SDA MBED_CONF_ATMEL_RF_I2C_SDA
+#endif
+#ifdef MBED_CONF_ATMEL_RF_I2C_SCL
+#define PIN_I2C_SCL MBED_CONF_ATMEL_RF_I2C_SCL
+#endif
+
+/* Yotta configuration */
+#ifdef YOTTA_CFG_ATMEL_RF_I2C_SDA
+#define PIN_I2C_SDA YOTTA_CFG_ATMEL_RF_I2C_SDA
+#endif
+#ifdef YOTTA_CFG_ATMEL_RF_I2C_SCL
+#define PIN_I2C_SCL YOTTA_CFG_ATMEL_RF_I2C_SCL
+#endif
+
+/* Defaults for Arduino form factor, or Yotta */
 #if defined TARGET_FF_ARDUINO || defined YOTTA_CFG
-#ifndef YOTTA_CFG_ATMEL_RF_I2C_SDA
-#define YOTTA_CFG_ATMEL_RF_I2C_SDA D14
+#ifndef PIN_I2C_SDA
+#define PIN_I2C_SDA D14
 #endif
-#ifndef YOTTA_CFG_ATMEL_RF_I2C_SCL
-#define YOTTA_CFG_ATMEL_RF_I2C_SCL D15
+#ifndef PIN_I2C_SCL
+#define PIN_I2C_SCL D15
 #endif
-#endif //TARGET_FF_ARDUINO
+#endif //TARGET_FF_ARDUINO || YOTTA_CFG
+
+/* Final fallback defines so we at least compile */
+#ifndef PIN_I2C_SDA
+#define PIN_I2C_SDA NC
+#endif
+#ifndef PIN_I2C_SCL
+#define PIN_I2C_SCL NC
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/source/driverAtmelRFInterface.cpp
+++ b/source/driverAtmelRFInterface.cpp
@@ -19,11 +19,6 @@
 #include "driverAtmelRFInterface.h"
 #include "mbed-drivers/mbed.h"
 
-// Pending better config support, we gate compilation
-// on this being defined. Which will be for Arduino
-// form factors, or if manually configured.
-#ifdef YOTTA_CFG_ATMEL_RF_SPI_MOSI
-
 // HW pins to RF chip
 #define SPI_SPEED 7500000
 
@@ -40,13 +35,11 @@ struct RFBits {
 };
 
 RFBits::RFBits() :
-spi(YOTTA_CFG_ATMEL_RF_SPI_MOSI,
-    YOTTA_CFG_ATMEL_RF_SPI_MISO,
-    YOTTA_CFG_ATMEL_RF_SPI_SCLK),
-CS(YOTTA_CFG_ATMEL_RF_SPI_CS),
-RST(YOTTA_CFG_ATMEL_RF_SPI_RST),
-SLP_TR(YOTTA_CFG_ATMEL_RF_SPI_SLP),
-IRQ(YOTTA_CFG_ATMEL_RF_SPI_IRQ) { }
+spi(PIN_SPI_MOSI, PIN_SPI_MISO, PIN_SPI_SCLK),
+CS(PIN_SPI_CS),
+RST(PIN_SPI_RST),
+SLP_TR(PIN_SPI_SLP),
+IRQ(PIN_SPI_IRQ) { }
 
 void (*app_rf_settings_cb)(void) = 0;
 static RFBits *rf;
@@ -940,6 +933,3 @@ uint8_t rf_if_spi_exchange(uint8_t out)
   // delay_ns(250);
   return v;
 }
-
-#endif //YOTTA_CFG_ATMEL_RF_SPI_MOSI
-

--- a/source/driverAtmelRFInterface.h
+++ b/source/driverAtmelRFInterface.h
@@ -154,29 +154,99 @@ extern "C" {
  *  }
  */
 
+/* mbed-cli configuration */
+#ifdef MBED_CONF_ATMEL_RF_SPI_MOSI
+#define PIN_SPI_MOSI MBED_CONF_ATMEL_RF_SPI_MOSI
+#endif
+#ifdef MBED_CONF_ATMEL_RF_SPI_MISO
+#define PIN_SPI_MISO MBED_CONF_ATMEL_RF_SPI_MISO
+#endif
+#ifdef MBED_CONF_ATMEL_RF_SPI_SCLK
+#define PIN_SPI_SCLK MBED_CONF_ATMEL_RF_SPI_SCLK
+#endif
+#ifdef MBED_CONF_ATMEL_RF_SPI_CS
+#define PIN_SPI_CS MBED_CONF_ATMEL_RF_SPI_CS
+#endif
+#ifdef MBED_CONF_ATMEL_RF_SPI_RST
+#define PIN_SPI_RST MBED_CONF_ATMEL_RF_SPI_RST
+#endif
+#ifdef MBED_CONF_ATMEL_RF_SPI_SLP
+#define PIN_SPI_SLP MBED_CONF_ATMEL_RF_SPI_SLP
+#endif
+#ifdef MBED_CONF_ATMEL_RF_SPI_IRQ
+#define PIN_SPI_IRQ MBED_CONF_ATMEL_RF_SPI_IRQ
+#endif
+
+/* Yotta configuration */
+#ifdef YOTTA_CFG_ATMEL_RF_SPI_MOSI
+#define PIN_SPI_MOSI YOTTA_CFG_ATMEL_RF_SPI_MOSI
+#endif
+#ifdef YOTTA_CFG_ATMEL_RF_SPI_MISO
+#define PIN_SPI_MISO YOTTA_CFG_ATMEL_RF_SPI_MISO
+#endif
+#ifdef YOTTA_CFG_ATMEL_RF_SPI_SCLK
+#define PIN_SPI_SCLK YOTTA_CFG_ATMEL_RF_SPI_SCLK
+#endif
+#ifdef YOTTA_CFG_ATMEL_RF_SPI_CS
+#define PIN_SPI_CS YOTTA_CFG_ATMEL_RF_SPI_CS
+#endif
+#ifdef YOTTA_CFG_ATMEL_RF_SPI_RST
+#define PIN_SPI_RST YOTTA_CFG_ATMEL_RF_SPI_RST
+#endif
+#ifdef YOTTA_CFG_ATMEL_RF_SPI_SLP
+#define PIN_SPI_SLP YOTTA_CFG_ATMEL_RF_SPI_SLP
+#endif
+#ifdef YOTTA_CFG_ATMEL_RF_SPI_IRQ
+#define PIN_SPI_IRQ YOTTA_CFG_ATMEL_RF_SPI_IRQ
+#endif
+
+/* Defaults for Arduino form factor, or Yotta */
 #if defined TARGET_FF_ARDUINO || defined YOTTA_CFG
-#ifndef YOTTA_CFG_ATMEL_RF_SPI_MOSI
-#define YOTTA_CFG_ATMEL_RF_SPI_MOSI D11
+#ifndef PIN_SPI_MOSI
+#define PIN_SPI_MOSI D11
 #endif
-#ifndef YOTTA_CFG_ATMEL_RF_SPI_MISO
-#define YOTTA_CFG_ATMEL_RF_SPI_MISO D12
+#ifndef PIN_SPI_MISO
+#define PIN_SPI_MISO D12
 #endif
-#ifndef YOTTA_CFG_ATMEL_RF_SPI_SCLK
-#define YOTTA_CFG_ATMEL_RF_SPI_SCLK D13
+#ifndef PIN_SPI_SCLK
+#define PIN_SPI_SCLK D13
 #endif
-#ifndef YOTTA_CFG_ATMEL_RF_SPI_CS
-#define YOTTA_CFG_ATMEL_RF_SPI_CS D10
+#ifndef PIN_SPI_CS
+#define PIN_SPI_CS D10
 #endif
-#ifndef YOTTA_CFG_ATMEL_RF_SPI_RST
-#define YOTTA_CFG_ATMEL_RF_SPI_RST D5
+#ifndef PIN_SPI_RST
+#define PIN_SPI_RST D5
 #endif
-#ifndef YOTTA_CFG_ATMEL_RF_SPI_SLP
-#define YOTTA_CFG_ATMEL_RF_SPI_SLP D7
+#ifndef PIN_SPI_SLP
+#define PIN_SPI_SLP D7
 #endif
-#ifndef YOTTA_CFG_ATMEL_RF_SPI_IRQ
-#define YOTTA_CFG_ATMEL_RF_SPI_IRQ D9
+#ifndef PIN_SPI_IRQ
+#define PIN_SPI_IRQ D9
 #endif
-#endif // TARGET_FF_ARDUINO
+#endif // TARGET_FF_ARDUINO || YOTTA_CFG
+
+/* Final fallback defines so we at least compile */
+#ifndef PIN_SPI_MOSI
+#define PIN_SPI_MOSI NC
+#endif
+#ifndef PIN_SPI_MISO
+#define PIN_SPI_MISO NC
+#endif
+#ifndef PIN_SPI_SCLK
+#define PIN_SPI_SCLK NC
+#endif
+#ifndef PIN_SPI_CS
+#define PIN_SPI_CS NC
+#endif
+#ifndef PIN_SPI_RST
+#define PIN_SPI_RST NC
+#endif
+#ifndef PIN_SPI_SLP
+#define PIN_SPI_SLP NC
+#endif
+#ifndef PIN_SPI_IRQ
+#define PIN_SPI_IRQ NC
+#endif
 
 void rf_if_cca_timer_start(uint32_t slots);
 void rf_if_enable_promiscuous_mode(void);

--- a/source/driverRFPhy.c
+++ b/source/driverRFPhy.c
@@ -22,8 +22,6 @@
 #include "randLIB.h"
 #include "at24mac.h"
 
-#ifdef YOTTA_CFG_ATMEL_RF_SPI_MOSI
-
 /*RF receive buffer*/
 static uint8_t rf_buffer[RF_BUFFER_SIZE];
 /*ACK wait duration changes depending on data rate*/
@@ -1260,5 +1258,3 @@ uint8_t rf_scale_lqi(int8_t rssi)
 
     return scaled_lqi;
 }
-
-#endif //YOTTA_CFG_ATMEL_RF_SPI_MOSI


### PR DESCRIPTION
Add support for configuration via mbed-cli configuration mechanism,
and fall back to compiling with NC if we don't find any pin definitions.

ifdeffing out the code was causing link errors with the ARM linker - with
the NC define, all references to the radio driver should now be resolved
on initial link scan, after which an unused radio/6LoWPAN stack should go
on to be omitted.