### PR TITLE
Add mbed_lib.json

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,0 +1,14 @@
+{
+    "name": "atmel-rf",
+    "config": {
+        "spi-mosi": null,
+        "spi-miso": null,
+        "spi-sclk": null,
+        "spi-cs": null,
+        "spi-rst": null,
+        "spi-slp": null,
+        "spi-irq": null,
+        "i2c-sda": null, 
+        "i2c-scl": null 
+    }
+}


### PR DESCRIPTION
Applications can't set the configuration settings if the mbed_lib.json
doesn't exist, with the options named. Add the file.

All options unset by default - this lets the code do its own defaulting.
(The code has built-in defaults for Arduino form factor, but not for
others.)