### PR TITLE
 Checking the presence of EUI-64 Chip

### DIFF
--- a/source/driverAtmelRFInterface.cpp
+++ b/source/driverAtmelRFInterface.cpp
@@ -24,9 +24,7 @@
 
 #ifdef MBED_CONF_RTOS_PRESENT
 #include "mbed.h"
-#include "Mutex.h"
-#include "Thread.h"
-using namespace rtos;
+#include "rtos.h"
 
 static void rf_if_irq_task_process_irq();
 


### PR DESCRIPTION
* On customer demand, if application defines not to use or if the platform
  doesn't have EUI-64 chip, the processing continues with and it checks whether
  the user have provided with a unique MAC address or not.

* User will provide the Unique MAC address

* User should use rf_set_mac_adress() routine to set MAC address before calling the
  rp_phy_register() routine.