### PR TITLE
Make inline assembler work with GCC+Thumb1

### DIFF
--- a/source/NanostackRfPhyAtmel.cpp
+++ b/source/NanostackRfPhyAtmel.cpp
@@ -339,9 +339,13 @@ static void delay_loop(uint32_t count)
 {
   __asm__ volatile (
     "%=:\n\t"
+#if defined(__thumb__) && !defined(__thumb2__)
+    "SUB  %0, #1\n\t"
+#else
     "SUBS %0, %0, #1\n\t"
+#endif
     "BCS  %=b\n\t"
-    : "+r" (count)
+    : "+l" (count)
     :
     : "cc"
   );


### PR DESCRIPTION
GCC insists on using a different assembler syntax for Thumb1. Adjust the
assembly code to cope.

Tweak the register directive to be "l" to make it a low register in GCC,
so it works for Thumb1. (Documentation says that's a synonym for "r" if
ARM).

IAR says that its "r" means a low register if Thumb, so not modifying that.