### PR TITLE
[ONME-3113] Fix ARM compiler warning

### DIFF
--- a/atmel-rf-driver/NanostackRfPhyAtmel.h
+++ b/atmel-rf-driver/NanostackRfPhyAtmel.h
@@ -57,11 +57,11 @@ public:
     NanostackRfPhyAtmel(PinName spi_mosi, PinName spi_miso,
             PinName spi_sclk, PinName spi_cs,  PinName spi_rst, PinName spi_slp, PinName spi_irq,
             PinName i2c_sda, PinName i2c_scl);
-    ~NanostackRfPhyAtmel();
-    int8_t rf_register();
-    void rf_unregister();
-    void get_mac_address(uint8_t *mac);
-    void set_mac_address(uint8_t *mac);
+    virtual ~NanostackRfPhyAtmel();
+    virtual int8_t rf_register();
+    virtual void rf_unregister();
+    virtual void get_mac_address(uint8_t *mac);
+    virtual void set_mac_address(uint8_t *mac);
 
 private:
     AT24Mac _mac;

--- a/source/NanostackRfPhyAtmel.cpp
+++ b/source/NanostackRfPhyAtmel.cpp
@@ -21,7 +21,7 @@
 #include "randLIB.h"
 #include "AT86RFReg.h"
 #include "nanostack/platform/arm_hal_phy.h"
-#include "toolchain.h"
+#include "mbed_toolchain.h"
 
 /*Worst case sensitivity*/
 #define RF_DEFAULT_SENSITIVITY -88


### PR DESCRIPTION
Warning #1300-D: inherits implicit virtual
- Adding the virtual keyword in the derived class prevents the warning

Warning #1215-D: #warning directive: toolchain.h has been replaced by
mbed_toolchain.h, please update to mbed_toolchain.h [since mbed-os-5.3]