### PR TITLE
Use an MBED_CONF_ define for the Atmel RF driver stack size

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -20,6 +20,10 @@
         "assume-spaced-spi":  {
             "help": "If not using SPI spacing API, assume platform has widely-spaced bytes in bursts, so use full clock speed rather than low.",
             "value": false
+        },
+        "irq-thread-stack-size":  {
+            "help": "The stack size of the Thread serving the Atmel RF interrupts",
+            "value": 1024
         }
     },
     "target_overrides": {

--- a/source/NanostackRfPhyAtmel.cpp
+++ b/source/NanostackRfPhyAtmel.cpp
@@ -271,7 +271,7 @@ RFBits::RFBits(PinName spi_mosi, PinName spi_miso,
         SLP_TR(spi_slp),
         IRQ(spi_irq)
 #ifdef MBED_CONF_RTOS_PRESENT
-,irq_thread(osPriorityRealtime, 1024)
+,irq_thread(osPriorityRealtime, MBED_CONF_ATMEL_RF_IRQ_THREAD_STACK_SIZE, NULL, "atmel_irq_thread")
 #endif
 {
 #ifdef MBED_CONF_RTOS_PRESENT


### PR DESCRIPTION
Use a define for the Atmel RF driver stack size (MBED_CONF_ATMEL_RF_IRQ_THREAD_STACK_SIZE)

Defined in mbed_lib.json. Override it in your mbed_app.json.

We have found that 1k was not enough in our use case and want to have it configurable and overridable.

While at it, we have also named the thread so that its easy to recognize in the stack overflow tools of mbedOS.