### PR TITLE
Remove error printing from the interrupt context

### DIFF
--- a/source/NanostackRfPhyAtmel.cpp
+++ b/source/NanostackRfPhyAtmel.cpp
@@ -1103,7 +1103,8 @@ static void rf_if_interrupt_handler(void)
   }
   if (irq_status & TRX_UR)
   {
-    tr_error("Radio underrun is %x->%x ts %x->%x fl %x->%x x1 %x", last_is, irq_status, last_ts, full_trx_status, orig_flags, rf_flags, orig_xah_ctrl_1);
+    // Here some counter could be used to monitor the underrun occurancy count.
+    // Do not print anything here!
   }
   last_is = irq_status;
   last_ts = full_trx_status;


### PR DESCRIPTION
Printing from the interrupt context caused serious problems in the 6lowpan devices.