### PR TITLE
Add define for Atmel RF driver stack size

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -24,6 +24,10 @@
         "provide-default": {
             "help": "Provide default NanostackRfpy. [true/false]",
             "value": false
+        },
+        "irq-thread-stack-size":  {
+            "help": "The stack size of the Thread serving the Atmel RF interrupts",
+            "value": 1024
         }
     },
     "target_overrides": {

--- a/source/NanostackRfPhyAtmel.cpp
+++ b/source/NanostackRfPhyAtmel.cpp
@@ -270,7 +270,7 @@ RFBits::RFBits(PinName spi_mosi, PinName spi_miso,
         SLP_TR(spi_slp),
         IRQ(spi_irq)
 #ifdef MBED_CONF_RTOS_PRESENT
-    , irq_thread(osPriorityRealtime, 1024)
+    , irq_thread(osPriorityRealtime, MBED_CONF_ATMEL_RF_IRQ_THREAD_STACK_SIZE, NULL, "atmel_irq_thread")
 #endif
 {
 #ifdef MBED_CONF_RTOS_PRESENT


### PR DESCRIPTION
Use configuration value MBED_CONF_ATMEL_RF_IRQ_THREAD_STACK_SIZE to
adjust stack size. Value defined in mbed_lib.json and can be
overridden in mbed_app.json.

This will rebase https://github.com/ARMmbed/atmel-rf-driver/pull/64 to top of master.

@SeppoTakalo 